### PR TITLE
Fix for not having a production url possible in axios.baseurl

### DIFF
--- a/src/components/utils/AxiosWithAuth.js
+++ b/src/components/utils/AxiosWithAuth.js
@@ -1,14 +1,25 @@
-import axios from 'axios';
+import axios from "axios";
 
 const AxiosWithAuth = () => {
-  const token = localStorage.getItem('token');
-  
+  const token = localStorage.getItem("token");
+
   return axios.create({
-    baseURL: process.env.REACT_APP_ENV === "development" ? process.env.REACT_APP_LOCAL_HOST : process.env.REACT_APP_STAGING_URL,
+    baseURL: (function() {
+      switch (process.env.REACT_APP_ENV) {
+        case "development":
+          return process.env.REACT_APP_LOCAL_HOST;
+        case "staging":
+          return process.env.REACT_APP_STAGING_URL;
+        case "production":
+          return process.env.REACT_APP_PRODUCTION_URL;
+        default:
+          return process.env.REACT_APP_LOCAL_HOST;
+      }
+    })(),
     headers: {
-      Authorization: token,
-      'Content-Type': 'application/json'
-    }
+      "Authorization": token,
+      "Content-Type": "application/json",
+    },
   });
 };
 


### PR DESCRIPTION
# Description

Fixes missing option for using the production url in baseURL of axiosWithAuth

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Running the app locally and changing the app_env to see if it switches to the different baseURLs

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
