### PR TITLE
Hiding moderation tools if team owner is looking at themselves.

### DIFF
--- a/src/components/team/EditMemberCard.js
+++ b/src/components/team/EditMemberCard.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { UserContext } from "../utils/UserContext";
 import { useParams } from "react-router-dom";
 import { Card, Modal, Icon, Tooltip } from 'antd';
 import { connect } from 'react-redux';
@@ -9,7 +10,7 @@ const { confirm } = Modal;
 function EditMemberCard(props) {
 	// #region CLICK UNCOLLAPSE ICON TO SHOW COMPONENT LOGIC
 	const { team_id } = useParams();
-	const { member } = props;
+	const { member, isSelf } = props;
 
 	const handleDelete = () => {
 		props.deleteTeamMember(team_id, member.user_id);
@@ -77,7 +78,9 @@ function EditMemberCard(props) {
 	}
 	// #endregion CLICK UNCOLLAPSE ICON TO SHOW COMPONENT LOGIC
 
-	return (
+	const { userRole } = useContext(UserContext)
+
+	return (isSelf === false &&
 		<Card className="edit-card">
 			<Card.Grid style={{ width: "50%", textAlign: 'center', padding: 0 }}>
 				{member.role_id === 1

--- a/src/components/team/EditMemberCard.js
+++ b/src/components/team/EditMemberCard.js
@@ -78,8 +78,6 @@ function EditMemberCard(props) {
 	}
 	// #endregion CLICK UNCOLLAPSE ICON TO SHOW COMPONENT LOGIC
 
-	const { userRole } = useContext(UserContext)
-
 	return (isSelf === false &&
 		<Card className="edit-card">
 			<Card.Grid style={{ width: "50%", textAlign: 'center', padding: 0 }}>

--- a/src/components/team/MemberCard.js
+++ b/src/components/team/MemberCard.js
@@ -7,6 +7,7 @@ import EditMemberCard from './EditMemberCard';
 function MemberCard(props) {
 	const { userRole } = useContext(UserContext)
 	const { data } = props;
+	const isSelf = data.user_id === props.userId
 
 	return (
 		<Card
@@ -18,8 +19,8 @@ function MemberCard(props) {
 				{(!data.avatar) ? (<Avatar size={64} icon="user" />) : (
 					<img alt="user avatar" src={`https://video-journal.herokuapp.com/public/avatars/${data.avatar}`} />)}
 			</div>
-			{userRole === 1 ? null : (<EditMemberCard member={data} />)}
 			<p className="small">{data.user_full_name}</p>
+			{userRole === 1 ? null : (<EditMemberCard member={data} isSelf={isSelf} />)}
 		</Card>
 	)
 }


### PR DESCRIPTION
# Description

If the userid of the logged in user is the same as the userid being shown on a team, then hide the moderation tools.

- [x] New feature (non-breaking change which adds functionality)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [ ] There are no merge conflicts
